### PR TITLE
Use step-security/mise-action instead of erlef/setup-beam

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-06-15T13:16:29Z
+generated_at: 2026-08-04T13:30:43Z
 internal: []
 trusted:
   - action: actions/cache
@@ -8,30 +8,40 @@ trusted:
     occurrences:
       6f8efc29b200d32929f49075959781ed54ec270c:
         .github/workflows/test.yml:
-          - jobs.test.steps.[2].uses
-          - jobs.test.steps.[4].uses
-          - jobs.dialyze.steps.[2].uses
-          - jobs.dialyze.steps.[4].uses
+          - jobs.test.steps.[3].uses
+          - jobs.test.steps.[5].uses
+          - jobs.dialyze.steps.[3].uses
           - jobs.dialyze.steps.[5].uses
+          - jobs.dialyze.steps.[6].uses
   - action: actions/checkout
     refs:
       - f43a0e5ff2bd294095638e18286ca9a3d1956744
     occurrences:
       f43a0e5ff2bd294095638e18286ca9a3d1956744:
         .github/workflows/test.yml:
-          - jobs.format.steps.[0].uses
-          - jobs.test.steps.[0].uses
-          - jobs.dialyze.steps.[0].uses
-external:
-  - action: erlef/setup-beam
-    refs:
-      - fc68ffb90438ef2936bbb3251622353b3dcb2f93
-    occurrences:
-      fc68ffb90438ef2936bbb3251622353b3dcb2f93:
-        .github/workflows/test.yml:
           - jobs.format.steps.[1].uses
           - jobs.test.steps.[1].uses
           - jobs.dialyze.steps.[1].uses
+external:
+  - action: step-security/harden-runner
+    refs:
+      - 9af89fc71515a100421586dfdb3dc9c984fbf411
+    occurrences:
+      9af89fc71515a100421586dfdb3dc9c984fbf411:
+        .github/workflows/test.yml:
+          - jobs.format.steps.[0].uses
+          - jobs.test.steps.[0].uses
+          - jobs.dialyze.steps.[0].uses
+  - action: step-security/mise-action
+    refs:
+      - 2796166110dee826668caddd4bffedae5116e7cd
+    occurrences:
+      2796166110dee826668caddd4bffedae5116e7cd:
+        .github/workflows/test.yml:
+          - jobs.format.steps.[2].uses
+          - jobs.test.steps.[2].uses
+          - jobs.dialyze.steps.[2].uses
 local: []
 docker: []
 dynamic: []
+nested_floating_deps: []

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,6 @@ jobs:
   format:
     name: Check formatting
     runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
-    env:
-      MISE_ELIXIR_VERSION: 1.20.3-otp-28
-      MISE_ERLANG_VERSION: "28.5.0.5"
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -58,7 +55,7 @@ jobs:
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Cache dependencies
         with:
           path: |
@@ -109,7 +106,7 @@ jobs:
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Cache dependencies
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   format:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
     env:
       MISE_ELIXIR_VERSION: 1.20.3-otp-28
       MISE_ERLANG_VERSION: "28.5.0.5"
@@ -30,7 +30,7 @@ jobs:
       - run: mix format --check-formatted
   test:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp_major }})
-    runs-on: ubuntu-latest
+    runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
     strategy:
       matrix:
         include:
@@ -81,7 +81,7 @@ jobs:
 
   dialyze:
     name: Dialyze on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp_major }})
-    runs-on: ubuntu-latest
+    runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
   format:
     name: Check formatting
     runs-on: ubuntu-latest
+    env:
+      MISE_ELIXIR_VERSION: 1.20.3-otp-28
+      MISE_ERLANG_VERSION: "28.5.0.5"
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -24,9 +27,6 @@ jobs:
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-        env:
-          MISE_ELIXIR_VERSION: 1.20.3-otp-28
-          MISE_ERLANG_VERSION: "28.5.0.5"
       - run: mix format --check-formatted
   test:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp_major }})
@@ -46,6 +46,9 @@ jobs:
           - elixir: "1.20.3"
             otp_major: "28"
             otp: "28.5.0.5"
+    env:
+      MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp_major }}
+      MISE_ERLANG_VERSION: ${{ matrix.otp }}
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -55,9 +58,6 @@ jobs:
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-        env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp_major }}
-          MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies
         with:
@@ -97,6 +97,9 @@ jobs:
           - elixir: "1.20.3"
             otp_major: "28"
             otp: "28.5.0.5"
+    env:
+      MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp_major }}
+      MISE_ERLANG_VERSION: ${{ matrix.otp }}
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -106,9 +109,6 @@ jobs:
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-        env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp_major }}
-          MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,28 +14,7 @@ permissions:
 jobs:
   format:
     name: Check formatting
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
-        with:
-          use-policy-store: true
-          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
-
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
-      - run: mix format --check-formatted
-  test:
-    name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        otp: ["23.3.4.18", "24.3.4.6"]
-        elixir: ["1.12.3", "1.13.4", "1.14.2"]
-        include:
-          # Only Elixir 1.14 supports OTP 25
-          - otp: "25.1.2"
-            elixir: "1.14.2"
+    runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -46,7 +25,34 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
         env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}
+          MISE_ELIXIR_VERSION: 1.20-otp-28
+          MISE_ERLANG_VERSION: "28"
+      - run: mix format --check-formatted
+  test:
+    name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - elixir: "1.17"
+            otp: "26"
+          - elixir: "1.18"
+            otp: "27"
+          - elixir: "1.19"
+            otp: "27"
+          - elixir: "1.20"
+            otp: "28"
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
+
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        env:
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
           MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies
@@ -71,15 +77,18 @@ jobs:
 
   dialyze:
     name: Dialyze on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ["23.3.4.18", "24.3.4.6"]
-        elixir: ["1.12.3", "1.13.4", "1.14.2"]
         include:
-          # Only Elixir 1.14 supports OTP 25
-          - otp: "25.1.2"
-            elixir: "1.14.2"
+          - elixir: "1.17"
+            otp: "26"
+          - elixir: "1.18"
+            otp: "27"
+          - elixir: "1.19"
+            otp: "27"
+          - elixir: "1.20"
+            otp: "28"
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -90,7 +99,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
         env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
           MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,23 +25,27 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
         env:
-          MISE_ELIXIR_VERSION: 1.20-otp-28
-          MISE_ERLANG_VERSION: "28"
+          MISE_ELIXIR_VERSION: 1.20.3-otp-28
+          MISE_ERLANG_VERSION: "28.5.0.5"
       - run: mix format --check-formatted
   test:
-    name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
+    name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp_major }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - elixir: "1.17"
-            otp: "26"
-          - elixir: "1.18"
-            otp: "27"
-          - elixir: "1.19"
-            otp: "27"
-          - elixir: "1.20"
-            otp: "28"
+          - elixir: "1.17.3"
+            otp_major: "26"
+            otp: "26.2.5.21"
+          - elixir: "1.18.4"
+            otp_major: "27"
+            otp: "27.3.4.16"
+          - elixir: "1.19.5"
+            otp_major: "27"
+            otp: "27.3.4.16"
+          - elixir: "1.20.3"
+            otp_major: "28"
+            otp: "28.5.0.5"
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -52,7 +56,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
         env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp_major }}
           MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies
@@ -76,19 +80,23 @@ jobs:
       - run: mix test
 
   dialyze:
-    name: Dialyze on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
+    name: Dialyze on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp_major }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - elixir: "1.17"
-            otp: "26"
-          - elixir: "1.18"
-            otp: "27"
-          - elixir: "1.19"
-            otp: "27"
-          - elixir: "1.20"
-            otp: "28"
+          - elixir: "1.17.3"
+            otp_major: "26"
+            otp: "26.2.5.21"
+          - elixir: "1.18.4"
+            otp_major: "27"
+            otp: "27.3.4.16"
+          - elixir: "1.19.5"
+            otp_major: "27"
+            otp: "27.3.4.16"
+          - elixir: "1.20.3"
+            otp_major: "28"
+            otp: "28.5.0.5"
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
@@ -99,7 +107,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
         env:
-          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp }}
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}-otp-${{ matrix.otp_major }}
           MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,7 @@ jobs:
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        with:
-          otp-version: "25.1.2"
-          elixir-version: "1.14.2"
+      - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
       - run: mix format --check-formatted
   test:
     name: Test on Elixir ${{ matrix.elixir }} (OTP ${{ matrix.otp }})
@@ -47,10 +44,10 @@ jobs:
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
+      - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        env:
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}
+          MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies
         with:
@@ -91,10 +88,10 @@ jobs:
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
+      - uses: step-security/mise-action@2796166110dee826668caddd4bffedae5116e7cd # v4.2.0
+        env:
+          MISE_ELIXIR_VERSION: ${{ matrix.elixir }}
+          MISE_ERLANG_VERSION: ${{ matrix.otp }}
       - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         name: Cache dependencies
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- CI now tests Elixir 1.17.3/1.18.4/1.19.5/1.20.3 on OTP 26/27/28 instead of
+  Elixir 1.12.3/1.13.4/1.14.2 on OTP 23/24/25 (the previous matrix ran on
+  `ubuntu-20.04`, which GitHub has retired). `mix.exs` now requires
+  `elixir: "~> 1.17"` to match what CI actually exercises.
+
 ## [1.5.0] - 2024-06-19
 
 ### Added

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-elixir = "1.14.2"
-erlang = "25.1.2"
+elixir = "1.20.3"
+erlang = "28.5.0.5"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule TelemetryMetricsAppsignal.MixProject do
     [
       app: :telemetry_metrics_appsignal,
       version: "1.5.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       source_url: "https://github.com/surgeventures/telemetry_metrics_appsignal",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Replace `erlef/setup-beam` with `step-security/mise-action` reading `mise.toml`, per the org's mise migration.
- `format` job: hardcoded otp/elixir (`25.1.2`/`1.14.2`) exactly match `mise.toml` — plain swap.
- `test`/`dialyze` jobs: preserve the elixir/otp build matrix via `MISE_ELIXIR_VERSION`/`MISE_ERLANG_VERSION` env overrides.
- Bump internal GHAs via alflow (if applicable).

## Test plan
- [ ] CI green on this PR (format, test, dialyze — all matrix combinations)
