### PR TITLE
chore: Support telemetric_metrics 1.2 `tag` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support functions in the `Telemetry.Metrics` `:tags` option.
+
 ### Changed
 
 - CI now tests Elixir 1.17.3/1.18.4/1.19.5/1.20.3 on OTP 26/27/28 instead of

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -148,6 +148,10 @@ defmodule TelemetryMetricsAppsignal do
 
   defp prepare_metric_value(_, _, _), do: nil
 
+  defp prepare_metric_tags(%{tags: tags}, metadata) when is_function(tags, 1) do
+    tags.(metadata)
+  end
+
   defp prepare_metric_tags(metric, metadata) do
     tag_values = metric.tag_values.(metadata)
     Map.take(tag_values, metric.tags)

--- a/mix.lock
+++ b/mix.lock
@@ -22,7 +22,7 @@
   "ordinal": {:hex, :ordinal, "0.2.0", "d3eda0cb04ee1f0ca0aae37bf2cf56c28adce345fe56a75659031b6068275191", [:mix], [], "hexpm", "defca8f10dee9f03a090ed929a595303252700a9a73096b6f2f8d88341690d65"},
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
-  "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
-  "telemetry_metrics": {:hex, :telemetry_metrics, "1.0.0", "29f5f84991ca98b8eb02fc208b2e6de7c95f8bb2294ef244a176675adc7775df", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "f23713b3847286a534e005126d4c959ebcca68ae9582118ce436b521d1d47d5d"},
+  "telemetry": {:hex, :telemetry, "1.4.2", "a0cb522801dffb1c49fe6e30561badffc7b6d0e180db1300df759faa22062855", [:rebar3], [], "hexpm", "928f6495066506077862c0d1646609eed891a4326bee3126ba54b60af61febb1"},
+  "telemetry_metrics": {:hex, :telemetry_metrics, "1.2.0", "7632c19c01d88d8aaca5da1a0e8912f5af39b79e7c08a2c253aeb3c14c2c957e", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "71dde12fc29b58b9c77ec17ec319109e5ca848d010fc1965ed4463bba1837c07"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -319,6 +319,34 @@ defmodule TelemetryMetricsAppsignalTest do
     for tags <- tag_permutations, do: assert_receive({^ref, ^tags})
   end
 
+  test "specifying metric tags with a function ignores other metadata" do
+    metric = last_value("worker.queue.length", tags: &get_queue/1)
+    start_reporter(metrics: [metric])
+
+    parent = self()
+    ref = make_ref()
+
+    expect(AppsignalMock, :set_gauge, 2, fn
+      "worker.queue.length", 42, tags ->
+        send(parent, {ref, tags})
+        :ok
+    end)
+
+    assert capture_log(fn ->
+             :telemetry.execute(
+               [:worker, :queue],
+               %{length: 42},
+               %{queue: "mailer", ignored: "metadata"}
+             )
+           end) == ""
+
+    assert_receive({^ref, queue_tags})
+    assert queue_tags == %{queue: "MAILER"}
+
+    assert_receive({^ref, fallback_tags})
+    assert fallback_tags == %{queue: "any"}
+  end
+
   test "specifying metric tag values" do
     metric = last_value("worker.queue.length", tags: [:value], tag_values: &get_and_put_value/1)
     start_reporter(metrics: [metric])
@@ -364,6 +392,10 @@ defmodule TelemetryMetricsAppsignalTest do
 
   defp get_and_put_value(metadata) do
     Map.put_new(metadata, :value, "value")
+  end
+
+  defp get_queue(metadata) do
+    %{queue: String.upcase(metadata.queue)}
   end
 
   defp fetch_attached_handlers do


### PR DESCRIPTION
Adds support for function-valued `:tags` introduced in `telemetry_metrics` 1.2 while preserving the existing list-based `:tags` and deprecated `:tag_values` behavior.

## What changed?

- Execute function-valued `:tags` directly with the event metadata and use the returned map as the complete metric tag set.
- Keep the existing list-based `:tags` plus `:tag_values` extraction path unchanged.
- Update the lockfile to `telemetry_metrics` 1.2.0.

## Why make these changes?

- `telemetry_metrics` 1.2 supersedes `:tag_values` by allowing `:tags` to be a one-argument function, but reporters must explicitly support the new form.
- Without this change, passing a function as `:tags` reaches `Map.take/2`, which expects a list of keys and causes event reporting to fail.

## References

- [beam-telemetry/telemetry_metrics#128](https://github.com/beam-telemetry/telemetry_metrics/pull/128), especially see `ConsoleReporter`
