### PR TITLE
chore: bump actions to ratified manifest SHAs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
         with:
           use-policy-store: true
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3
       - uses: step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7 # v4.2.4
         with:
           version: '2026.8.12'
@@ -33,16 +33,16 @@ jobs:
     runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
         with:
           use-policy-store: true
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3
       - uses: step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7 # v4.2.4
         with:
           version: '2026.8.12'
-      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.7
         name: Cache dependencies
         with:
           path: |
@@ -52,7 +52,7 @@ jobs:
             deps-${{ hashFiles('mix.lock') }}
             deps-
       - run: mix deps.get
-      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.7
         name: Cache build
         with:
           path: |
@@ -68,16 +68,16 @@ jobs:
     runs-on: "runs-on/runner=4cpu-linux-x64/run-id=${{ github.run_id }}"
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2
         with:
           use-policy-store: true
           api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
 
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3
       - uses: step-security/mise-action@6e96d2ffbc65c037f23c78818f2a339d6cf830f7 # v4.2.4
         with:
           version: '2026.8.12'
-      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.7
         name: Cache dependencies
         with:
           path: |
@@ -87,7 +87,7 @@ jobs:
             deps-${{ hashFiles('mix.lock') }}
             deps-
       - run: mix deps.get
-      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.7
         name: Cache build
         with:
           path: |
@@ -96,7 +96,7 @@ jobs:
           restore-keys: |
             build-${{ runner.os }}-${{ hashFiles('mix.lock') }}
             build-${{ runner.os }}-
-      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.7
         name: Restore PLT cache
         id: plt_cache
         with:


### PR DESCRIPTION
Manual rollout from actions-manifest's current ratified state (actions-maintenance.yaml not yet wired up in this repo).


- actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 -> actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
- step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 -> step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1
- step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 -> step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93